### PR TITLE
Feature environment variables

### DIFF
--- a/config/xqerl.config
+++ b/config/xqerl.config
@@ -2,7 +2,7 @@
 %%
 %% xqerl - XQuery processor
 %%
-%% Copyright (c) 2017-2018 Zachary N. Dean  All Rights Reserved.
+%% Copyright (c) 2017-2020 Zachary N. Dean  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -27,7 +27,8 @@
 {code_dir      , "./code"},
 {port          , 8081},
 {trace_handler , xqerl_trace_h},
-{event_handlers, []}
+{event_handlers, []},
+{environment_access, false}
 ]},
 %% Index Settings
 {merge_index, 

--- a/config/xqerl.test.config
+++ b/config/xqerl.test.config
@@ -27,7 +27,8 @@
 {code_dir      , "./test/code"},
 {port          , 8081},
 {trace_handler , xqerl_trace_h},
-{event_handlers, []}
+{event_handlers, []},
+{environment_access, true}
 ]},
 %% Index Settings
 {merge_index, 

--- a/src/xqerl_mod_fn.erl
+++ b/src/xqerl_mod_fn.erl
@@ -2,7 +2,7 @@
 %%
 %% xqerl - XQuery processor
 %%
-%% Copyright (c) 2017-2019 Zachary N. Dean  All Rights Reserved.
+%% Copyright (c) 2017-2020 Zachary N. Dean  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -959,9 +959,13 @@ get_groups(_, _, [], _) ->
 %% fn:available-environment-variables() as xs:string*
 -spec 'available-environment-variables'(
         xq_types:context()) -> [].
-'available-environment-variables'(_Ctx) -> 
-   % NOT ALLOWING ACCESS TO ENVIRONMENT
-   [].
+'available-environment-variables'(Ctx) ->
+    case application:get_env(xqerl, environment_access, false) of
+        true ->
+            xqerl_lib:get_environment_variable_names(Ctx);
+        false ->
+            []
+    end.
 
 %% Returns the average of the values in the input sequence $arg, that is, 
 %% the sum of the values divided by the number of values. 
@@ -1903,9 +1907,14 @@ distinct_vals([Val|T], Acc) ->
 -spec 'environment-variable'(xq_types:context(),
                              xq_types:xs_string()) ->
          [] | xq_types:xs_string().
-'environment-variable'(_Ctx,_Arg1) -> 
-   %% NOT IMPLEMENTING
-   [].
+'environment-variable'(Ctx, Arg1) ->
+    case application:get_env(xqerl, environment_access, false) of
+        true ->
+            Str1 = xqerl_types:string_value(Arg1),
+            xqerl_lib:get_environment_variable(Ctx, Str1);
+        false ->
+            []
+    end.
 
 %% -record(xqError, {
 %%       name,

--- a/src/xqerl_static.erl
+++ b/src/xqerl_static.erl
@@ -2,7 +2,7 @@
 %%
 %% xqerl - XQuery processor
 %%
-%% Copyright (c) 2017-2019 Zachary N. Dean  All Rights Reserved.
+%% Copyright (c) 2017-2020 Zachary N. Dean  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -3321,20 +3321,26 @@ handle_node(State, ?CALL(#xqQName{namespace = ?FN,
     Type = ?seqtype(Line, 'xs:anyURI', zero_or_one),
     ArgSt = ?atomic('xs:anyURI', Base),
     set_statement_and_type(State, ArgSt, Type);
-% BLOCKed functions
-% TODO the rest of them...
 handle_node(State, ?CALL(#xqQName{namespace = ?FN,
-                                  local_name = <<"environment-variable">>}, 
-                         1, [Arg], Line)) -> 
+                                  local_name = <<"environment-variable">>} = Name, 
+                         1, [Arg], Line) = Call) -> 
+    F = get_static_function(State, {Name, 1}),
     Type = ?seqtype(Line, 'xs:string', zero_or_one),
     ArgS = handle_node(State, Arg),
+    ArgSt = get_statement(ArgS),
     _ = check_fun_arg_types(State, [ArgS], [?stringone(Line)], Line),   
-    set_statement_and_type(State, 'empty-sequence', Type);
+    set_statement_and_type(State,
+                           Call?CALL(F#xqFunctionDef{anno = Line,
+                                                     params = [ArgSt], 
+                                                     type = Type}, Line), Type);
 handle_node(State, ?CALL(#xqQName{namespace = ?FN,
-                                  local_name = <<"available-environment-variables">>}, 
-                         0, [], Line)) -> 
+                                  local_name = <<"available-environment-variables">>} = Name, 
+                         0, [], Line) = Call) -> 
+    F = get_static_function(State, {Name, 0}),
     Type = ?seqtype(Line, 'xs:string', zero_or_many),
-    set_statement_and_type(State, 'empty-sequence', Type);
+    set_statement_and_type(State,
+                           Call?CALL(F#xqFunctionDef{anno = Line, 
+                                                     type = Type}, Line), Type);
 % list distinct / takes type of the arg, unless node then xs:anyAtomicType
 handle_node(State, ?CALL(#xqQName{namespace = ?FN,
                                   local_name = <<"distinct-values">>} = Name, 

--- a/test/fn/fn_available_environment_variables_SUITE.erl
+++ b/test/fn/fn_available_environment_variables_SUITE.erl
@@ -26,6 +26,10 @@ end_per_suite(_Config) ->
    ct:timetrap({seconds,60}), 
    xqerl_code_server:unload(all).
 init_per_suite(Config) -> 
+   %% Special for this suite, variables must be set
+   true = os:putenv("QTTEST", "42"),
+   true = os:putenv("QTTEST2", "other"),
+   true = os:putenv("QTTESTEMPTY", ""),
    {ok,_} = application:ensure_all_started(xqerl),
    DD = filename:dirname(filename:dirname(filename:dirname(?config(data_dir, Config)))),
    TD = filename:join(DD, "QT3-test-suite"),

--- a/test/fn/fn_environment_variable_SUITE.erl
+++ b/test/fn/fn_environment_variable_SUITE.erl
@@ -27,6 +27,10 @@ end_per_suite(_Config) ->
    ct:timetrap({seconds,60}), 
    xqerl_code_server:unload(all).
 init_per_suite(Config) -> 
+   %% Special for this suite, variables must be set
+   true = os:putenv("QTTEST", "42"),
+   true = os:putenv("QTTEST2", "other"),
+   true = os:putenv("QTTESTEMPTY", ""),
    {ok,_} = application:ensure_all_started(xqerl),
    DD = filename:dirname(filename:dirname(filename:dirname(?config(data_dir, Config)))),
    TD = filename:join(DD, "QT3-test-suite"),


### PR DESCRIPTION
This adds a flag to the configuration to allow access to the OS environment variables.

`fn:environment-variable#1` and `fn:available-environment-variables#0` will function when the `environment_access` flag is set to `true`. It is set to `false` by default.

Relates to #28. 