### PR TITLE
Actions tar release

### DIFF
--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -115,6 +115,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
+    - name: Fetch tags
+      run: |
+        git fetch --force --tags
+        git describe --abbrev=0 || true
+        printf %60s | tr ' ' '-' && echo
     - name: Download built artifact
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -1,44 +1,78 @@
-name: xqerl
-on: [push]
+name: build check release
+on:
+  push:
+    branches: '*'
+    tags:
+      - 'v*'
 jobs:
-  # spec_tests:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #       image: erlang:22.0.7
-  #   steps:
-  #   - name: Checkout Repo
-  #     uses: actions/checkout@v1
-  #     with:
-  #       fetch-depth: 1
-      # - name: Compile Xqerl
-      # run: rebar3 compile
-  #   - name: spec tests
-  #     run: rebar3 ct --spec "test/test.specs"
   build:
     runs-on: ubuntu-latest
-    # container:
-    #     image: erlang:22.0.7
     steps:
     - name: checkout repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
-        fetch-depth: 1
-    - name: Compile xqerl
-      run: rebar3 compile
-    - name: Build release
+        fetch-depth: 0
+    - name: Fetch tags
       run: |
-          sudo chown -R $USER /usr/local
-          rebar3 release -o /usr/local
-          printf %60s | tr ' ' '-' && echo
-          ln -s /usr/local/xqerl/bin/xqerl /usr/local/bin/xqerl
-          printf %60s | tr ' ' '-' && echo
-          which xqerl
-          printf %60s | tr ' ' '-' && echo
-    - name: Start up xqerl
-      run: xqerl daemon
-    - name: Beam inspection 
+        git fetch --force --tags
+        git describe --abbrev=0
+        printf %60s | tr ' ' '-' && echo
+    - name: Cache dependiencies
+      id: cache-deps
+      uses: actions/cache@v2
+      with:
+        path: _build
+        key: rebar-${{ hashFiles('./rebar.lock') }}
+        # restore-keys: rebar-
+    - name: Cache dependiencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
-          sleep 5
+        rebar3 deps
+        rebar3 compile
+    - name: build production tar
+      run: |
+        rebar3 as prod tar
+        mkdir _release
+        mv _build/prod/rel/xqerl/*.tar.gz _release/xqerl.tar.gz
+    - name: Upload built artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: xqerl-prod-tar
+        path: _release/
+  checks:
+    if: ${{ github.ref_type == 'branch' }}    
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch tags
+      run: |
+        git fetch --force --tags
+        git describe --abbrev=0
+        printf %60s | tr ' ' '-' && echo
+    - name: Download built artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: xqerl-prod-tar
+    - name: Unpack release tar and install xqerl application
+      run: |
+        mkdir -p  $HOME/.local/xqerl
+        mkdir -p  $HOME/.local/bin
+        tar -zxf xqerl.tar.gz -C $HOME/.local/xqerl
+        ln -s $HOME/.local/xqerl/bin/xqerl $HOME/.local/bin
+        ls -al $HOME/.local/bin
+        echo $PATH
+        which xqerl
+    - name: Start the xqerl application
+      run: |
+        xqerl daemon
+        sleep 2
+        xqerl eval 'application:ensure_all_started(xqerl).'
+    - name: Checks - OTP Beam inspection 
+      run: |
           printf %60s | tr ' ' '-' && echo
           echo -n '-  ping: ' 
           xqerl ping | grep -oP 'pong'
@@ -46,10 +80,10 @@ jobs:
           xqerl pid | grep -oP '\d+'
           printf %60s | tr ' ' '-' && echo
           echo -n ' - set xqerl working directory: '
-          xqerl eval "file:set_cwd(\"$(pwd)\")."
+          xqerl eval "file:set_cwd('$(pwd)')."
           xqerl eval 'file:get_cwd().'
           printf %60s | tr ' ' '=' && echo
-    - name: Can do
+    - name: Checks - xqerl eval on running instance
       run: |
           printf %60s | tr ' ' '-' && echo
           echo ' - run a xQuery expression'
@@ -69,10 +103,10 @@ jobs:
           'xqldb_dml:insert_doc("http://xqerl.org/my_doc.xml","./test/QT3-test-suite/app/FunctxFn/functx_order.xml").' | \
           grep -oP 'ok'
           printf %60s | tr ' ' '-' && echo
-          echo ' - view using the fn:doc#1 function and the xqerl:run/1 function'
-          xqerl eval 'io:format(xqerl_node:to_xml(xqerl:run("doc(\"http://xqerl.org/my_doc.xml\")"))).'
+          echo ' - view using the the xqerl:run/1 function with xQuery fn:doc#1 function'
+          xqerl eval "binary_to_list(xqerl:run(\" 'http://xqerl.org/my_doc.xml' => doc() => serialize() \"))."
           printf %60s | tr ' ' '-' && echo
-          echo -n ' - delete db doc'
+          echo -n ' - delete db doc '
           xqerl eval 'xqldb_dml:delete_doc("http://xqerl.org/my_doc.xml").' |  \
           grep -oP 'ok'
           printf %60s | tr ' ' '-' && echo
@@ -80,5 +114,42 @@ jobs:
           xqerl eval 'xqldb_dml:import_from_directory("http://xqerl.org/tests/", "./test/QT3-test-suite").' | \
           grep -oP 'ok'
           printf %60s | tr ' ' '=' && echo
-    - name: stop xqerl
+    - name: Stop xqerl
       run: xqerl stop
+  release:
+    if: ${{ github.ref_type == 'tag' }}    
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch tags
+      run: |
+        git fetch --force --tags
+        git describe --abbrev=0
+        printf %60s | tr ' ' '-' && echo
+    - name: Download built artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: xqerl-prod-tar
+    - name: Release artifact
+      run: |
+        VERSION=$(echo ${RELEASE} | sed s/v// )
+        NOTE="$(git tag -l --format='%(contents:subject)' ${RELEASE})"
+        echo $MESSAGE
+        # note is annotated tag message
+        mv ./xqerl.tar.gz  ./xqerl-${VERSION}.tar.gz
+        gh release create ${RELEASE} "./xqerl-${VERSION}.tar.gz#xqerl-${VERSION}" \
+        --notes "${NOTE}"  \
+        --title "xqerl release ${RELEASE}" \
+        --target  ${SHA} --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        SHA: ${{github.sha}}
+        RELEASE: ${{github.ref_name}}
+        MESSAGE: ${{ github.event.head_commit.message }}
+  # #   # rebar3 hex publish --repo hexpm --yes

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -11,12 +11,7 @@ jobs:
     - name: checkout repo
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-    - name: Fetch tags
-      run: |
-        git fetch --force --tags
-        git describe --abbrev=0
-        printf %60s | tr ' ' '-' && echo
+        fetch-depth: 1
     - name: Cache dependiencies
       id: cache-deps
       uses: actions/cache@v2
@@ -48,11 +43,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Fetch tags
-      run: |
-        git fetch --force --tags
-        git describe --abbrev=0
-        printf %60s | tr ' ' '-' && echo
     - name: Download built artifact
       uses: actions/download-artifact@v2
       with:
@@ -124,12 +114,7 @@ jobs:
     - name: checkout repo
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-    - name: Fetch tags
-      run: |
-        git fetch --force --tags
-        git describe --abbrev=0
-        printf %60s | tr ' ' '-' && echo
+        fetch-depth: 1
     - name: Download built artifact
       uses: actions/download-artifact@v2
       with:

--- a/rebar.config
+++ b/rebar.config
@@ -34,15 +34,23 @@
             {sys_config, ["config/xqerl.test.config"]},
             {logopts, [no_src]}
         ]}
+    ]},
+    {prod, [
+        {relx, [
+            {dev_mode, false},
+            {include_src, false},
+            {include_erts, true}
+            % {debug_info, strip} TODO!
+        ]}
     ]}
 ]}.
 
 {relx, [
-    {release, {xqerl, "0.8.1"}, [xqerl]},
+    {release, {xqerl, {git, long}}, [xqerl]},
     {sys_config, "config/xqerl.config"},
     {vm_args_src, "config/vm.args.src"},
-    {dev_mode, false},
-    {include_erts, true},
+    {dev_mode, true},
+    {include_erts, false},
     {extended_start_script, true},
     {overlay, [
         {mkdir, "log"},


### PR DESCRIPTION
Altered rebar.config to create a prod profile,
Altered github actions workflow file to create release asset

Separated github actions into 3 jobs.
1.  build:
    -  build dir is cached so after first compile and if rebar.lock is not changed then the action run will use the cached build dir.
    -  creates a tar via rebar3 as prod tar
    -  the tar is uploaded as a work-flow run artefact. The artefact is used in subsequent jobs.

 2.  checks: runs id ref_type is branch.  https://github.com/grantmacken/xqerl/actions/runs/1508884172
      Runs simple smoke tests to check if
       -  the tar can be successfully installed as an executable
       -  xqerl can be started and
          -  is running OK on the BEAM
          -  the database is storing, retrieving data
          -  xQuery expressions are runnable

3. release: runs if id ref_type is tag. https://github.com/grantmacken/xqerl/actions/runs/1508885894
  -  job is trigged after
     -   repo owner creates an annotated tag `git tag -a v0.0.1 -m ''xqerl first release''`
     -  repo owner pushes tag `git push --follow-tags`
  -  job uses gh to create the release
       -  the release note is derived from the annotated tag message
       - the tar originally created via rebar3 as prod tar is added as a release asset
       
The release on my fork
https://github.com/grantmacken/xqerl/releases
