### PR TITLE
Action docker images

### DIFF
--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -115,6 +115,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
+    - name: Fetch tags
+      run: |
+        git fetch --force --tags
+        git describe --abbrev=0 || true
+        printf %60s | tr ' ' '-' && echo
     - name: Download built artifact
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -1,44 +1,78 @@
-name: xqerl
-on: [push]
+name: build check release
+on:
+  push:
+    branches: '*'
+    tags:
+      - 'v*'
 jobs:
-  # spec_tests:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #       image: erlang:22.0.7
-  #   steps:
-  #   - name: Checkout Repo
-  #     uses: actions/checkout@v1
-  #     with:
-  #       fetch-depth: 1
-      # - name: Compile Xqerl
-      # run: rebar3 compile
-  #   - name: spec tests
-  #     run: rebar3 ct --spec "test/test.specs"
   build:
     runs-on: ubuntu-latest
-    # container:
-    #     image: erlang:22.0.7
     steps:
     - name: checkout repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
-        fetch-depth: 1
-    - name: Compile xqerl
-      run: rebar3 compile
-    - name: Build release
+        fetch-depth: 0
+    - name: Fetch tags
       run: |
-          sudo chown -R $USER /usr/local
-          rebar3 release -o /usr/local
-          printf %60s | tr ' ' '-' && echo
-          ln -s /usr/local/xqerl/bin/xqerl /usr/local/bin/xqerl
-          printf %60s | tr ' ' '-' && echo
-          which xqerl
-          printf %60s | tr ' ' '-' && echo
-    - name: Start up xqerl
-      run: xqerl daemon
-    - name: Beam inspection 
+        git fetch --force --tags
+        git describe --abbrev=0
+        printf %60s | tr ' ' '-' && echo
+    - name: Cache dependiencies
+      id: cache-deps
+      uses: actions/cache@v2
+      with:
+        path: _build
+        key: rebar-${{ hashFiles('./rebar.lock') }}
+        # restore-keys: rebar-
+    - name: Cache dependiencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
-          sleep 5
+        rebar3 deps
+        rebar3 compile
+    - name: build production tar
+      run: |
+        rebar3 as prod tar
+        mkdir _release
+        mv _build/prod/rel/xqerl/*.tar.gz _release/xqerl.tar.gz
+    - name: Upload built artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: xqerl-prod-tar
+        path: _release/
+  checks:
+    if: ${{ github.ref_type == 'branch' }}    
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch tags
+      run: |
+        git fetch --force --tags
+        git describe --abbrev=0
+        printf %60s | tr ' ' '-' && echo
+    - name: Download built artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: xqerl-prod-tar
+    - name: Unpack release tar and install xqerl application
+      run: |
+        mkdir -p  $HOME/.local/xqerl
+        mkdir -p  $HOME/.local/bin
+        tar -zxf xqerl.tar.gz -C $HOME/.local/xqerl
+        ln -s $HOME/.local/xqerl/bin/xqerl $HOME/.local/bin
+        ls -al $HOME/.local/bin
+        echo $PATH
+        which xqerl
+    - name: Start the xqerl application
+      run: |
+        xqerl daemon
+        sleep 2
+        xqerl eval 'application:ensure_all_started(xqerl).'
+    - name: Checks - OTP Beam inspection 
+      run: |
           printf %60s | tr ' ' '-' && echo
           echo -n '-  ping: ' 
           xqerl ping | grep -oP 'pong'
@@ -46,10 +80,10 @@ jobs:
           xqerl pid | grep -oP '\d+'
           printf %60s | tr ' ' '-' && echo
           echo -n ' - set xqerl working directory: '
-          xqerl eval "file:set_cwd(\"$(pwd)\")."
+          xqerl eval "file:set_cwd('$(pwd)')."
           xqerl eval 'file:get_cwd().'
           printf %60s | tr ' ' '=' && echo
-    - name: Can do
+    - name: Checks - xqerl eval on running instance
       run: |
           printf %60s | tr ' ' '-' && echo
           echo ' - run a xQuery expression'
@@ -69,10 +103,10 @@ jobs:
           'xqldb_dml:insert_doc("http://xqerl.org/my_doc.xml","./test/QT3-test-suite/app/FunctxFn/functx_order.xml").' | \
           grep -oP 'ok'
           printf %60s | tr ' ' '-' && echo
-          echo ' - view using the fn:doc#1 function and the xqerl:run/1 function'
-          xqerl eval 'io:format(xqerl_node:to_xml(xqerl:run("doc(\"http://xqerl.org/my_doc.xml\")"))).'
+          echo ' - view using the the xqerl:run/1 function with xQuery fn:doc#1 function'
+          xqerl eval "binary_to_list(xqerl:run(\" 'http://xqerl.org/my_doc.xml' => doc() => serialize() \"))."
           printf %60s | tr ' ' '-' && echo
-          echo -n ' - delete db doc'
+          echo -n ' - delete db doc '
           xqerl eval 'xqldb_dml:delete_doc("http://xqerl.org/my_doc.xml").' |  \
           grep -oP 'ok'
           printf %60s | tr ' ' '-' && echo
@@ -80,5 +114,42 @@ jobs:
           xqerl eval 'xqldb_dml:import_from_directory("http://xqerl.org/tests/", "./test/QT3-test-suite").' | \
           grep -oP 'ok'
           printf %60s | tr ' ' '=' && echo
-    - name: stop xqerl
+    - name: Stop xqerl
       run: xqerl stop
+  release:
+    if: ${{ github.ref_type == 'tag' }}    
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch tags
+      run: |
+        git fetch --force --tags
+        git describe --abbrev=0
+        printf %60s | tr ' ' '-' && echo
+    - name: Download built artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: xqerl-prod-tar
+    - name: Release artifact
+      run: |
+        VERSION=$(echo ${RELEASE} | sed s/v// )
+        NOTE="$(git tag -l --format='%(contents:subject)' ${RELEASE})"
+        echo $MESSAGE
+        # note is annotated tag message
+        mv ./xqerl.tar.gz  ./xqerl-${VERSION}.tar.gz
+        gh release create ${RELEASE} "./xqerl-${VERSION}.tar.gz#xqerl-${VERSION}" \
+        --notes "${NOTE}"  \
+        --title "xqerl release ${RELEASE}" \
+        --target  ${SHA} --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        SHA: ${{github.sha}}
+        RELEASE: ${{github.ref_name}}
+        MESSAGE: ${{ github.event.head_commit.message }}
+  # #   # rebar3 hex publish --repo hexpm --yes

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'v*'
 jobs:
+  # allways runs - creates workflow _build cache and artifact
   build:
     runs-on: ubuntu-latest
     steps:
@@ -12,19 +13,19 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - name: Cache dependiencies
+    - name: Cache the _build dir
       id: cache-deps
       uses: actions/cache@v2
       with:
         path: _build
         key: rebar-${{ hashFiles('./rebar.lock') }}
         # restore-keys: rebar-
-    - name: Cache dependiencies
+    - name: If no cache hit get then deps and compile
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         rebar3 deps
         rebar3 compile
-    - name: build production tar
+    - name: Build production tar
       run: |
         rebar3 as prod tar
         mkdir _release
@@ -143,9 +144,9 @@ jobs:
         RELEASE: ${{github.ref_name}}
         MESSAGE: ${{ github.event.head_commit.message }}
   package:
-    # TODO: change to tag after testing workflow
-    if: ${{ github.ref_type == 'build' }}    
-    needs: release
+    # TODO: if change to tag after testing workflow
+    if: ${{ github.ref_type == 'tag' }}    
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - name: checkout repo
@@ -157,30 +158,90 @@ jobs:
         git fetch --force --tags
         git describe --abbrev=0 || true
         printf %60s | tr ' ' '-' && echo
-    - name: Download built artifact
-      uses: actions/download-artifact@v2
+    - name: Fetch the cached _build
+      id: cache-deps
+      uses: actions/cache@v2
       with:
-        name: xqerl-prod-tar
-    - name: buildah build
+        path: _build
+        key: rebar-${{ hashFiles('./rebar.lock') }}
+    - name: Buildah build
       run: |
         VERSION=$(git describe --abbrev=0 | sed s/v// )
-        echo $VERSION
-        ERL_VER=24.1.7
-        CONTAINER=$$(buildah from docker.io/erlang:${ERL_VER}-alpine)
-        buildah copy ${CONTAINER} ./xqerl.tar.gz /home/xqerl.tar.gz
-        buildah run ${CONTAINER} mkdir -p /user/local/xqerl /usr/local/bin
-        buildah run tar -zxf xqerl.tar.gz /user/local/xqerl
-        buildah run ln -s /user/local/xqerl /usr/local/bin
-        buildah run ls -al /usr/local/bin
-        buildah run echo $PATH
-        buildah run which xqerl
-        buildah commit --rm $${CONTAINER} localhost/xqerl
-        buildah tag localhost/xqerl ghcr.io/$(OWNER)/xqerl:$(VERSION)
+        ALPINE_VERSION=3.15
+        ERLANG_VERSION=24-alpine
+        echo "version: $VERSION"
+        echo " - build from alpine version: $ALPINE_VERSION "
+        BASE_CONTAINER=$(buildah from docker.io/erlang:${ERLANG_VERSION})
+        buildah copy ${BASE_CONTAINER} ./ /home/
+        buildah run ${BASE_CONTAINER} sh -c 'apk add --update git tar \
+        && cd /home \
+        && rebar3 as prod tar \
+        && mkdir /usr/local/xqerl \
+        && tar -zxf _build/prod/rel/*/*.tar.gz -C /usr/local/xqerl'
+        CONTAINER=$(buildah from docker.io/alpine:${ALPINE_VERSION})
+        buildah run ${CONTAINER} sh -c 'apk add --no-cache openssl ncurses-libs tzdata libstdc++ \
+        && mkdir /usr/local/xqerl \
+        && cd /usr/local/bin \
+        && ln -s /usr/local/xqerl/bin/xqerl'
+        buildah copy --from ${BASE_CONTAINER} $CONTAINER /usr/local/xqerl /usr/local/xqerl  
+        printf %60s | tr ' ' '-' && echo
+        echo " -  check"
+        buildah run ${CONTAINER} sh -c 'ls -al /usr/local/bin | grep -q xqerl'
+        buildah run ${CONTAINER} sh -c 'which xqerl' # should error if failsto find   
+        #printf %60s | tr ' ' '-' && echo
+        #buildah run ${CONTAINER}  sh -c 'echo $PATH' || true
+        #printf %60s | tr ' ' '-' && echo
+        echo " - set working dir and entry point"
+        buildah config --cmd '' ${CONTAINER}
+        buildah config --workingdir /usr/local/xqerl ${CONTAINER}
+        buildah config --entrypoint '[ "xqerl", "foreground"]' ${CONTAINER}
+        echo " - set environment vars"
+        buildah config --env LANG=C.UTF-8 ${CONTAINER}
+        buildah config --env HOME=/home ${CONTAINER}
+        buildah config --env XQERL_HOME=/usr/local/xqerl ${CONTAINER}
+        printf %60s | tr ' ' '-' && echo
+        buildah run ${CONTAINER}  sh -c 'printenv' || true
+        printf %60s | tr ' ' '-' && echo
+        echo " - set stop signal"
+        buildah config --stop-signal SIGQUIT ${CONTAINER}
+        echo " - set labels"
+        buildah config --label org.opencontainers.image.title='xqerl' ${CONTAINER}
+        buildah config --label org.opencontainers.image.description='Erlang XQuery 3.1 Processor and XML Database' ${CONTAINER}
+        buildah config --label org.opencontainers.image.source=https://github.com/${OWNER}/${REPO} ${CONTAINER} # where the image is built
+        buildah config --label org.opencontainers.image.version='${VERSION}' ${CONTAINER} # version
+        buildah commit --rm ${CONTAINER} localhost/xqerl
+        printf %60s | tr ' ' '-' && echo
+        echo " - list docker images"
+        podman images
+        printf %60s | tr ' ' '-' && echo
+        #echo " - inspect image"
+        #podman inspect localhost/xqerl | jq '.'
+        echo " - run container with sh as entrypoint"
+        podman run --rm --entrypoint '["/bin/sh", "-c"]' localhost/xqerl 'ls -al .'
+        echo " - run container with published ports"
+        podman run --name xq --publish 8081:8081 --detach localhost/xqerl
+        sleep 2
+        echo " - check log"
+        printf %60s | tr ' ' '-' && echo
+        podman logs -n -t --since 0 -l
+        printf %60s | tr ' ' '-' && echo
+        echo -n ' - check running: ' 
+        podman container inspect -f '{{.State.Running}}' xq
+        podman exec xq xqerl eval "application:ensure_all_started(xqerl)."
+        podman ps -a
+        podman stop xq || true
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Push to GitHub Container Registry
+      run: |
+        VERSION=$(git describe --abbrev=0 | sed s/v// )
+        echo " - tag image - ghcr.io/${OWNER}/xqerl:${VERSION}"
+        buildah tag localhost/xqerl ghcr.io/${OWNER}/xqerl:${VERSION}
+        buildah push ghcr.io/${OWNER}/xqerl:${VERSION}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OWNER: ${{ github.repository_owner }}
         REPO: ${{ github.event.repository.name }}
-        SHA: ${{github.sha}}
-        RELEASE: ${{github.ref_name}}
-  # #   # rebar3 hex publish --repo hexpm --yes
-  # #   # rebar3 hex publish --repo hexpm --yes

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -142,4 +142,45 @@ jobs:
         SHA: ${{github.sha}}
         RELEASE: ${{github.ref_name}}
         MESSAGE: ${{ github.event.head_commit.message }}
+  package:
+    # TODO: change to tag after testing workflow
+    if: ${{ github.ref_type == 'build' }}    
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch tags
+      run: |
+        git fetch --force --tags
+        git describe --abbrev=0 || true
+        printf %60s | tr ' ' '-' && echo
+    - name: Download built artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: xqerl-prod-tar
+    - name: buildah build
+      run: |
+        VERSION=$(git describe --abbrev=0 | sed s/v// )
+        echo $VERSION
+        ERL_VER=24.1.7
+        CONTAINER=$$(buildah from docker.io/erlang:${ERL_VER}-alpine)
+        buildah copy ${CONTAINER} ./xqerl.tar.gz /home/xqerl.tar.gz
+        buildah run ${CONTAINER} mkdir -p /user/local/xqerl /usr/local/bin
+        buildah run tar -zxf xqerl.tar.gz /user/local/xqerl
+        buildah run ln -s /user/local/xqerl /usr/local/bin
+        buildah run ls -al /usr/local/bin
+        buildah run echo $PATH
+        buildah run which xqerl
+        buildah commit --rm $${CONTAINER} localhost/xqerl
+        buildah tag localhost/xqerl ghcr.io/$(OWNER)/xqerl:$(VERSION)
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        SHA: ${{github.sha}}
+        RELEASE: ${{github.ref_name}}
+  # #   # rebar3 hex publish --repo hexpm --yes
   # #   # rebar3 hex publish --repo hexpm --yes

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -11,12 +11,7 @@ jobs:
     - name: checkout repo
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-    - name: Fetch tags
-      run: |
-        git fetch --force --tags
-        git describe --abbrev=0
-        printf %60s | tr ' ' '-' && echo
+        fetch-depth: 1
     - name: Cache dependiencies
       id: cache-deps
       uses: actions/cache@v2
@@ -48,11 +43,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Fetch tags
-      run: |
-        git fetch --force --tags
-        git describe --abbrev=0
-        printf %60s | tr ' ' '-' && echo
     - name: Download built artifact
       uses: actions/download-artifact@v2
       with:
@@ -124,12 +114,7 @@ jobs:
     - name: checkout repo
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-    - name: Fetch tags
-      run: |
-        git fetch --force --tags
-        git describe --abbrev=0
-        printf %60s | tr ' ' '-' && echo
+        fetch-depth: 1
     - name: Download built artifact
       uses: actions/download-artifact@v2
       with:

--- a/rebar.config
+++ b/rebar.config
@@ -34,15 +34,23 @@
             {sys_config, ["config/xqerl.test.config"]},
             {logopts, [no_src]}
         ]}
+    ]},
+    {prod, [
+        {relx, [
+            {dev_mode, false},
+            {include_src, false},
+            {include_erts, true}
+            % {debug_info, strip} TODO!
+        ]}
     ]}
 ]}.
 
 {relx, [
-    {release, {xqerl, "0.8.1"}, [xqerl]},
+    {release, {xqerl, {git, long}}, [xqerl]},
     {sys_config, "config/xqerl.config"},
     {vm_args_src, "config/vm.args.src"},
-    {dev_mode, false},
-    {include_erts, true},
+    {dev_mode, true},
+    {include_erts, false},
     {extended_start_script, true},
     {overlay, [
         {mkdir, "log"},


### PR DESCRIPTION
Add action job to  create docker image based on the latest release tag.
Image is built using [buildah](https://buildah.io/) so no dockerfile is required.
Image is pushed to the github container registry  and is available in github packages 