### PR TITLE
Fix 60 package failure

### DIFF
--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -243,20 +243,20 @@ jobs:
         buildah push ghcr.io/${GITHUB_REPOSITORY}:${VERSION}
       env:
         RELEASE: ${{github.ref_name}}
-    # - name: Login to Docker Container Registry
-    #   if: "${{ env.DOCKER_TOKEN != '' }}"
-    #   uses: docker/login-action@v1
-    #   with:
-    #     registry: docker.io
-    #     username: ${{ github.actor }}
-    #     password: ${{ secrets.DOCKER_TOKEN }}
-    #   env:
-    #     DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-    # - name: Push to Docker Container Registry
-    #   run: |
-    #     VERSION=$(echo "${RELEASE}" | sed s/v// )
-    #     buildah tag localhost/xqerl docker.io/${GITHUB_REPOSITORY}:${VERSION}
-    #     buildah push docker.io/${GITHUB_REPOSITORY}:${VERSION}
-    #   env:
-    #     RELEASE: ${{github.ref_name}}
-    #     DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+    - name: Login to Docker Container Registry
+      if: "${{ env.DOCKER_TOKEN != '' }}"
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+      env:
+        DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+    - name: Push to Docker Container Registry
+      run: |
+        VERSION=$(echo "${RELEASE}" | sed s/v// )
+        buildah tag localhost/xqerl docker.io/${GITHUB_REPOSITORY}:${VERSION}
+        buildah push docker.io/${GITHUB_REPOSITORY}:${VERSION}
+      env:
+        RELEASE: ${{github.ref_name}}
+        DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -253,6 +253,7 @@ jobs:
       env:
         DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     - name: Push to Docker Container Registry
+      if: "${{ env.DOCKER_TOKEN != '' }}"
       run: |
         VERSION=$(echo "${RELEASE}" | sed s/v// )
         buildah tag localhost/xqerl docker.io/${GITHUB_REPOSITORY}:${VERSION}

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -38,7 +38,7 @@ jobs:
         name: xqerl-prod-tar
         path: _release/
   checks:
-    if: ${{ github.ref_type == 'branch' }}    
+    if: ${{ github.ref_type == 'branch' }}
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -165,9 +165,9 @@ jobs:
         key: rebar-${{ hashFiles('./rebar.lock') }}
     - name: Buildah build
       run: |
-        VERSION=$(git describe --abbrev=0 | sed s/v// )
+        VERSION=$(echo "${RELEASE}" | sed s/v// )
         ALPINE_VERSION=3.15
-        ERLANG_VERSION=24-alpine
+        ERLANG_VERSION=24.3-alpine
         echo "version: $VERSION"
         echo " - build from alpine version: $ALPINE_VERSION "
         BASE_CONTAINER=$(buildah from docker.io/erlang:${ERLANG_VERSION})
@@ -226,6 +226,9 @@ jobs:
         podman exec xq xqerl eval "application:ensure_all_started(xqerl)."
         podman ps -a
         podman stop xq || true
+      env:
+        SHA: ${{github.sha}}
+        RELEASE: ${{github.ref_name}}
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:
@@ -234,7 +237,26 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Push to GitHub Container Registry
       run: |
-        VERSION=$(git describe --abbrev=0 | sed s/v// )
+        VERSION=$(echo "${RELEASE}" | sed s/v// )
         echo " - tag image - ghcr.io/${GITHUB_REPOSITORY}:${VERSION}"
         buildah tag localhost/xqerl ghcr.io/${GITHUB_REPOSITORY}:${VERSION}
         buildah push ghcr.io/${GITHUB_REPOSITORY}:${VERSION}
+      env:
+        RELEASE: ${{github.ref_name}}
+    # - name: Login to Docker Container Registry
+    #   if: "${{ env.DOCKER_TOKEN != '' }}"
+    #   uses: docker/login-action@v1
+    #   with:
+    #     registry: docker.io
+    #     username: ${{ github.actor }}
+    #     password: ${{ secrets.DOCKER_TOKEN }}
+    #   env:
+    #     DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+    # - name: Push to Docker Container Registry
+    #   run: |
+    #     VERSION=$(echo "${RELEASE}" | sed s/v// )
+    #     buildah tag localhost/xqerl docker.io/${GITHUB_REPOSITORY}:${VERSION}
+    #     buildah push docker.io/${GITHUB_REPOSITORY}:${VERSION}
+    #   env:
+    #     RELEASE: ${{github.ref_name}}
+    #     DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
should fix #60 
dummy run 
https://github.com/grantmacken/xqerl/actions/runs/1966762308
now creates image in the gh packages registry
https://github.com/grantmacken/xqerl/pkgs/container/xqerl

The dummy run made the xqerl docker image available on docker-hub
https://hub.docker.com/r/grantmacken/xqerl

It only  pushes image to dockerhub if a github actions secret DOCKER_TOKEN is set
This assumes the repo owner name `zadean` is also the name of the  dockerhub account. 













