### PR TITLE
maintaining built in cowboy routes after restXQ routes updates

### DIFF
--- a/.github/workflows/feat.yml
+++ b/.github/workflows/feat.yml
@@ -110,7 +110,7 @@ jobs:
         curl -sSL -D - http://localhost:8081/assets/images/logo.png -o /dev/null
         curl -sSL -D - http://localhost:8081/assets/images/logo.png -o /dev/null | grep -q '200' 
         printf %60s | tr ' ' '=' && echo
-    - name:  after install have a xqerl greeter #48 
+    - name:  after install have a xqerl greeter - issue 48
       run: |
         echo '- use curl to check if http://localhost:8081/xqerl is reachable'
         printf %60s | tr ' ' '=' && echo
@@ -121,7 +121,7 @@ jobs:
     - name: maintain builtin routes - issue 66
       run: |
         echo ' - add restXQ route, then check if greeter service still available'
-        xqerl eval 'xqerl:compile("test/restxq/tests.xqm")'
+        xqerl eval 'xqerl:compile("test/restxq/tests.xqm").'
         sleep 1
         curl -sSL -D - http://localhost:8081/xqerl -o /dev/null
         curl -sS http://localhost:8081/xqerl | grep -oP '<title>.+</title>'

--- a/.github/workflows/feat.yml
+++ b/.github/workflows/feat.yml
@@ -118,10 +118,17 @@ jobs:
         printf %60s | tr ' ' '=' && echo
         curl -sS http://localhost:8081/xqerl | grep -oP '<title>.+</title>'
         printf %60s | tr ' ' '=' && echo    - name: Stop xqerl
+    - name: maintain builtin routes - issue 66
+      run: |
+        echo ' - add restXQ route, then check if greeter service still available'
+        xqerl eval 'xqerl:compile("test/restxq/tests.xqm")'
+        sleep 1
+        curl -sSL -D - http://localhost:8081/xqerl -o /dev/null
+        curl -sS http://localhost:8081/xqerl | grep -oP '<title>.+</title>'
     - name:  stop xqerl
       run: xqerl stop
   rest_db_checks:
-    if: ${{ github.ref_type == 'branch' }}    
+    if: ${{ github.ref_type == 'branch' }}
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/src/xqerl_code_server.erl
+++ b/src/xqerl_code_server.erl
@@ -670,10 +670,9 @@ remove_module_dispatch(Module, DispatchFile) ->
     _ = cowboy:set_env(xqerl_listener, dispatch, Dispatch),
     ok.
 
-
 % add builtin endpoints to restXQ endpoints
 set_cowboy_routes(EndPoints) ->
-  lists:flatten(
+    lists:flatten(
         [
             xqerl_restxq:endpoint_sort(EndPoints),
             {"/assets/[...]", cowboy_static, {priv_dir, xqerl, "static/assets"}},
@@ -681,7 +680,6 @@ set_cowboy_routes(EndPoints) ->
             {"/db/:domain/[...]", xqerl_handler_rest_db, #{}}
         ]
     ).
-
 
 write_dispatch(Filename, Term) ->
     Ser = io_lib:format("~tp.~n", [Term]),

--- a/src/xqerl_code_server.erl
+++ b/src/xqerl_code_server.erl
@@ -619,7 +619,8 @@ save_module(
 
 init_rest(DispatchFileName) ->
     Port = application:get_env(xqerl, port, 8081),
-    Paths =
+    % get restXQ endpoints from from dispatch file
+    EndPoints =
         case filelib:is_regular(DispatchFileName) of
             true ->
                 {ok, Dis} = file:consult(DispatchFileName),
@@ -632,14 +633,7 @@ init_rest(DispatchFileName) ->
                 ok = write_dispatch(DispatchFileName, Dis),
                 Dis
         end,
-    Routes = lists:flatten(
-        [
-            xqerl_restxq:endpoint_sort(Paths),
-            {"/assets/[...]", cowboy_static, {priv_dir, xqerl, "static/assets"}},
-            {"/xqerl", xqerl_handler_greeter, #{}},
-            {"/db/:domain/[...]", xqerl_handler_rest_db, #{}}
-        ]
-    ),
+    Routes = set_cowboy_routes(EndPoints),
     Dispatch = cowboy_router:compile([{'_', Routes}]),
     _ = cowboy:start_clear(
         xqerl_listener,
@@ -652,10 +646,12 @@ merge_load_dispatch(Module, Rest, DispatchFile) ->
     {ok, OldEndPoints} = file:consult(DispatchFile),
     NewEndPoints = xqerl_restxq:build_endpoints(Module, Rest),
     OldEndPoints1 = remove_module_from_endpoints(Module, OldEndPoints),
+    % revised restXQ endpoints written to dispatch file
     EndPoints = lists:flatten(NewEndPoints ++ OldEndPoints1),
-    DisTerm = xqerl_restxq:endpoint_sort(EndPoints),
-    Dispatch = cowboy_router:compile([{'_', DisTerm}]),
     _ = write_dispatch(DispatchFile, EndPoints),
+    Routes = set_cowboy_routes(EndPoints),
+    Dispatch = cowboy_router:compile([{'_', Routes}]),
+    % live update Routes
     _ = cowboy:set_env(xqerl_listener, dispatch, Dispatch),
     ok.
 
@@ -668,10 +664,24 @@ remove_module_dispatch(Module, DispatchFile) ->
     {ok, OldEndPoints} = file:consult(DispatchFile),
     EndPoints = remove_module_from_endpoints(Module, OldEndPoints),
     _ = write_dispatch(DispatchFile, EndPoints),
-    DisTerm = xqerl_restxq:endpoint_sort(EndPoints),
-    Dispatch = cowboy_router:compile([{'_', DisTerm}]),
+    Routes = set_cowboy_routes(EndPoints),
+    Dispatch = cowboy_router:compile([{'_', Routes}]),
+    % live update Routes
     _ = cowboy:set_env(xqerl_listener, dispatch, Dispatch),
     ok.
+
+
+% add builtin endpoints to restXQ endpoints
+set_cowboy_routes(EndPoints) ->
+  lists:flatten(
+        [
+            xqerl_restxq:endpoint_sort(EndPoints),
+            {"/assets/[...]", cowboy_static, {priv_dir, xqerl, "static/assets"}},
+            {"/xqerl", xqerl_handler_greeter, #{}},
+            {"/db/:domain/[...]", xqerl_handler_rest_db, #{}}
+        ]
+    ).
+
 
 write_dispatch(Filename, Term) ->
     Ser = io_lib:format("~tp.~n", [Term]),


### PR DESCRIPTION
- [x] builtin routes maintained after restXQ compile 
- [x] running instance check with github actions

xqerl has 3 built-in cowboy routes ( services )
1. xqerl greeter   @  {host}/xqerl     service serves 'now flying xqerl' greeter
2. static assets    @  {host}/assets  service serves assets from host file system in erlang priv dir
3. db  resources  @  {host}/db        service handles crud ops for db collections and resources via http methods

When restXQ routes  are re-compiled, the above routes are missing in action.
I have been working with a solution, in my fork, which seems to work ok.