### PR TITLE
add priv/bin for users escripts

### DIFF
--- a/.github/workflows/feat.yml
+++ b/.github/workflows/feat.yml
@@ -1,5 +1,7 @@
 name: checks on running xqerl instance
 on:
+  pull_request:
+    types: [ assigned, opened, synchronize, reopened ]
   push:
     branches-ignore:
       - main

--- a/.github/workflows/feat.yml
+++ b/.github/workflows/feat.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         name: xqerl-prod-tar
         path: _release/
-  checks:
+  xqerl_eval_checks:
     if: ${{ github.ref_type == 'branch' }}    
     needs: build
     runs-on: ubuntu-latest
@@ -44,10 +44,11 @@ jobs:
         name: xqerl-prod-tar
     - name: Unpack release tar and install xqerl application
       run: |
-        mkdir -p  $HOME/.local/xqerl
+        XQERL_HOME=$HOME/.local/xqerl
+        mkdir -p $XQERL_HOME
         mkdir -p  $HOME/.local/bin
-        tar -zxf xqerl.tar.gz -C $HOME/.local/xqerl
-        ln -s $HOME/.local/xqerl/bin/xqerl $HOME/.local/bin
+        tar -zxf xqerl.tar.gz -C $XQERL_HOME
+        ln -s $XQERL_HOME/bin/xqerl $HOME/.local/bin
         ls -al $HOME/.local/bin
         echo $PATH
         which xqerl
@@ -117,7 +118,7 @@ jobs:
         curl -sSL -D - http://localhost:8081/xqerl -o /dev/null
         printf %60s | tr ' ' '=' && echo
         curl -sS http://localhost:8081/xqerl | grep -oP '<title>.+</title>'
-        printf %60s | tr ' ' '=' && echo    - name: Stop xqerl
+        printf %60s | tr ' ' '=' && echo
     - name: maintain builtin routes - issue 66
       run: |
         echo ' - add restXQ route, then check if greeter service still available'
@@ -125,8 +126,7 @@ jobs:
         sleep 1
         curl -sSL -D - http://localhost:8081/xqerl -o /dev/null
         curl -sS http://localhost:8081/xqerl | grep -oP '<title>.+</title>'
-    - name:  stop xqerl
-      run: xqerl stop
+
   rest_db_checks:
     if: ${{ github.ref_type == 'branch' }}
     needs: build
@@ -140,10 +140,11 @@ jobs:
         name: xqerl-prod-tar
     - name: Unpack release tar and install xqerl application
       run: |
-        mkdir -p  $HOME/.local/xqerl
+        XQERL_HOME=$HOME/.local/xqerl
+        mkdir -p $XQERL_HOME
         mkdir -p  $HOME/.local/bin
-        tar -zxf xqerl.tar.gz -C $HOME/.local/xqerl
-        ln -s $HOME/.local/xqerl/bin/xqerl $HOME/.local/bin
+        tar -zxf xqerl.tar.gz -C $XQERL_HOME
+        ln -s $XQERL_HOME/bin/xqerl $HOME/.local/bin
     - name: Start the xqerl application
       run: |
         xqerl daemon
@@ -631,4 +632,66 @@ jobs:
         grep -oP 'HTTP(.+)404(.+)' ${CHECK_PATH}/headers.txt
         printf %60s | tr ' ' '=' && echo
     - name: Stop xqerl
+      run: xqerl stop
+
+  xqerl_escript_checks:
+    if: ${{ github.ref_type == 'branch' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v3
+    - name: Download built artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: xqerl-prod-tar
+    - name: Unpack release tar and install xqerl application
+      run: |
+        XQERL_HOME=$HOME/.local/xqerl
+        mkdir -p $XQERL_HOME
+        mkdir -p  $HOME/.local/bin
+        tar -zxf xqerl.tar.gz -C $XQERL_HOME
+        ln -s $XQERL_HOME/bin/xqerl $HOME/.local/bin
+    - name: Start the xqerl application
+      run: |
+        xqerl daemon
+        sleep 2
+        xqerl eval 'application:ensure_all_started(xqerl).'
+    - name: Set Up - add libs and docs
+      run: |
+        printf %60s | tr ' ' '-' && echo
+        xqerl eval "file:make_symlink(code:priv_dir(xqerl),\"./priv\")." | grep -q 'ok'
+        xqerl eval "file:set_cwd('$(pwd)')." | grep -q 'ok'
+        echo ' -  compile library module: '
+        xqerl eval 'xqerl:compile("test/restxq/tests.xqm").' &>/dev/null
+        echo ' - db import some XML docs: '
+        xqerl eval 'xqldb_dml:import_from_directory("http://xqerl.org/tests/", "./test/QT3-test-suite/docs").' | grep -q 'ok'
+        xqerl eval 'xqldb_dml:import_from_directory("http://example.com/examples/", "./test/QT3-test-suite/misc").' | grep -q 'ok'
+    - name: Checks - xqerl escript on running instance
+      run: |
+        printf %60s | tr ' ' '-' && echo
+        echo ' - list compiled library modules'
+        echo '> xqerl escript priv/bin/list-libs'
+        xqerl escript priv/bin/list-libs
+        printf %60s | tr ' ' '-' && echo
+        echo ' - list xqerl db contents'
+        echo '> xqerl escript priv/bin/list-db-uri'
+        xqerl escript priv/bin/list-db-uri
+    - name: Checks - as shebang executable escript
+      run: |
+        echo ' - make escript executable'
+        pushd ~/.local/xqerl/priv/bin/
+        chmod +x ./list-db-uri
+        echo ' - now exectable is callable'
+        echo '> ./list-db-uri'
+        ./list-db-uri
+        popd
+    - name: Checks - as callable executable on PATH
+      run: |
+        echo ' - create link to ~/.local/bin'
+        ln -sf ~/.local/xqerl/priv/bin/list-db-uri ~/.local/bin/xqerl-list-db-uri
+        echo ' - now exectable is callable from anywhere'
+        echo '> xqerl-list-db-uri'
+        xqerl-list-db-uri
+    - name:  stop xqerl
       run: xqerl stop

--- a/.github/workflows/feat.yml
+++ b/.github/workflows/feat.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: checkout repo
       uses: actions/checkout@v3

--- a/.github/workflows/feat.yml
+++ b/.github/workflows/feat.yml
@@ -38,6 +38,7 @@ jobs:
     if: ${{ github.ref_type == 'branch' }}    
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: checkout repo
       uses: actions/checkout@v3
@@ -134,6 +135,7 @@ jobs:
     if: ${{ github.ref_type == 'branch' }}
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: checkout repo
       uses: actions/checkout@v3
@@ -641,6 +643,7 @@ jobs:
     if: ${{ github.ref_type == 'branch' }}
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: checkout repo
       uses: actions/checkout@v3

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -2,11 +2,13 @@
 name: build check release
 on:
   push:
-    branches: 'main'
+    branches: 
+      - 'main'
     tags:
       - 'v*.*.*'
   pull_request:
-    branches: 'main'
+    branches: 
+      - 'main'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/xqerl.yml
+++ b/.github/workflows/xqerl.yml
@@ -6,9 +6,6 @@ on:
       - 'main'
     tags:
       - 'v*.*.*'
-  pull_request:
-    branches: 
-      - 'main'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/priv/bin/list-db-uri
+++ b/priv/bin/list-db-uri
@@ -1,0 +1,46 @@
+#!/usr/bin/env escript
+%% -*- coding: utf-8 -*-
+%%! -setcookie monster
+-define(SELF_NODE, list_to_atom( "escript_" ++ integer_to_list(rand:uniform(16#FFFFFFFFF)) ++ "@127.0.0.1")).
+
+-record(xqAtomicValue, {
+    type = undefined :: atom(),
+    value = undefined :: term() | []
+}).
+
+-record(xqError, {
+    name,
+    description = [],
+    value = [],
+    % {Module, Line, Column}
+    location = undefined,
+    additional = []
+}).
+
+print([]) -> ok;
+print([H|T]) ->
+  io:format("~s~n", [ binary_to_list(H#xqAtomicValue.value) ]),
+  print(T).
+
+formatError(E) -> 
+  io:format("~s ~n" , [ E#xqError.description ]),
+  halt(1).
+
+main([]) ->
+   {ok, _} = net_kernel:start([?SELF_NODE, longnames]),
+   Timeout = 1000,
+ try rpc:call( 'xqerl@127.0.0.1',
+                xqerl,
+                run,
+                ["for-each(uri-collection(),function($item){uri-collection($item)})"],
+                Timeout) of
+   E when is_record(E, xqError) -> formatError(E); 
+   A when is_record(A, xqAtomicValue) -> print([A]);
+   L when is_list(L) -> print(L)
+ catch 
+    _:_ -> halt(1)
+  end. 
+
+
+
+

--- a/priv/bin/list-libs
+++ b/priv/bin/list-libs
@@ -1,0 +1,24 @@
+#!/usr/bin/env escript
+%% -*- coding: utf-8 -*-
+%%! -setcookie monster
+-define(SELF_NODE, list_to_atom( "escript_" ++ integer_to_list(rand:uniform(16#FFFFFFFFF)) ++ "@127.0.0.1")).
+
+print([]) -> ok;
+print([H|T]) ->
+  io:format("~s~n", [ binary_to_list(H)]),
+  print(T).
+
+main([]) ->
+   {ok, _} = net_kernel:start([?SELF_NODE, longnames]),
+   Timeout = 1000,
+ try rpc:call( 'xqerl@127.0.0.1',
+                xqerl_code_server,
+                library_namespaces,
+                [],
+                Timeout) of
+    List when is_list(List) -> print(List)
+ catch 
+    _:_ -> halt(1)
+  end. 
+
+


### PR DESCRIPTION
Following the convention over configuration principle 
I think it would be nice to have a place to plonk escripts.

https://www.erlang.org/doc/design_principles/applications.html#id80846
> priv/bin - Recommended. Any executable that is used by the application, s

--------------------------------

 - [x] create priv/bin dir, add example escripts 
   - priv/bin/list-libs
   - priv/bin/list-db-uri

 - [x]  checks:(feat.yml)  xqerl escript on running instance
 ```
xqerl escript priv/bin/list-libs
xqerl escript priv/bin/list-db-uri
```
 - [x]  checks:(feat.yml)  as shebang executable escript 
 ```
pushd ~/.local/xqerl/priv/bin/
chmod +x ./list-db-uri
./list-db-uri
popd
```
 - [x]  checks:(feat.yml)  callable  executable on PATH 
 ```
ln -sf ~/.local/xqerl/priv/bin/list-db-uri ~/.local/bin/xqerl-list-db-uri
echo $PATH
# escript now callable from anywhere
xqerl-list-db-uri
```

--------------------------------

